### PR TITLE
Add automatic ALT generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ canonical: /zwierzeta/koty
 variant_of: koty
 image: /koty/29/koty-29.svg
 pdf: /koty/29/koty-29.pdf
+alt: "Kolorowanka koty"
 tags:
 - zwierzeta
 - koty
@@ -93,6 +94,17 @@ Znaleziono 12 plików SVG…
 ✅ kotek02.svg → koty-30
 ...
 ✅ Gotowe. Utworzono 12 wariantów (od 29 do 40).
+```
+
+## ➕ Dodawanie opisów ALT
+
+Skrypt automatycznie dodaje pola `alt` do generowanych plików `index.md`. Tekst
+jest rotowany z listy szablonów tak, aby kolejne warianty miały różne opisy.
+Jeśli chcesz zaktualizować ALT w już istniejących plikach, możesz użyć
+dodatkowego skryptu `update-alt.js`:
+
+```bash
+node update-alt.js <kategoria>
 ```
 
 ## 📄 Licencja

--- a/svg-to-pdf.js
+++ b/svg-to-pdf.js
@@ -23,6 +23,29 @@ const { readdirSync, mkdirSync, existsSync, copyFileSync, writeFileSync, readFil
 const { join, extname } = require('path');
 const { spawnSync } = require('child_process');
 
+// --- ALT Templates ---------------------------------------------------------
+const altTemplates = [
+  'Kolorowanka {{ zmienna }}',
+  'Kolorowanki {{ zmienna }}',
+  '{{ zmienna }} kolorowanka dla dzieci',
+  '{{ zmienna }} kolorowanki dla dzieci',
+  'Kolorowanka do druku {{ zmienna }}',
+  'Kolorowanki do druku {{ zmienna }}',
+  '{{ zmienna }} do druku i pokolorowania',
+  'Darmowa kolorowanka {{ zmienna }} do druku PDF',
+  '{{ zmienna }} – pobierz i wydrukuj kolorowankę',
+  'Kolorowanka z {{ zmienna }} do pobrania',
+  'Malowanka {{ zmienna }} do druku A4',
+  'kolorowanka do druku {{ zmienna }} PDF',
+  'Łatwa kolorowanka {{ zmienna }} dla przedszkolaka',
+  'Edukacyjna kolorowanka {{ zmienna }} do wydruku',
+  'Kogut kolorowanka dla dzieci',
+  'Kolorowanka {{ zmienna }} – format A4 PDF',
+  'Prosta kolorowanka {{ zmienna }} do kolorowania',
+  'Jednorożec kolorowanka',
+  'Pokoloruj {{ zmienna }} – darmowy szablon PDF'
+];
+
 // --- Argumenty CLI --------------------------------------------------------
 const [, , startArg, category] = process.argv;
 const startIndex = parseInt(startArg, 10);
@@ -123,6 +146,8 @@ svgs.forEach(file => {
 
   // 4) Generuj index.md
   const capitalCat = ucFirst(category);
+  const template = altTemplates[(current - startIndex) % altTemplates.length];
+  const altText = template.replace('{{ zmienna }}', category);
   const mdContent = `---\n` +
     `title: ${capitalCat}\n` +
     `description: Kolorowanka ${capitalCat} - wariant ${current}\n` +
@@ -130,6 +155,7 @@ svgs.forEach(file => {
     `variant_of: ${category}\n` +
     `image: /${category}/${current}/${base}.svg\n` +
     `pdf: /${category}/${current}/${base}.pdf\n` +
+    `alt: "${altText}"\n` +
     `tags:\n` +
     `- zwierzeta\n` +
     `- ${category}\n` +

--- a/update-alt.js
+++ b/update-alt.js
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+// Lista wzorców ALT do rotacji
+const altTemplates = [
+  'Kolorowanka {{ zmienna }}',
+  'Kolorowanki {{ zmienna }}',
+  '{{ zmienna }} kolorowanka dla dzieci',
+  '{{ zmienna }} kolorowanki dla dzieci',
+  'Kolorowanka do druku {{ zmienna }}',
+  'Kolorowanki do druku {{ zmienna }}',
+  '{{ zmienna }} do druku i pokolorowania',
+  'Darmowa kolorowanka {{ zmienna }} do druku PDF',
+  '{{ zmienna }} – pobierz i wydrukuj kolorowankę',
+  'Kolorowanka z {{ zmienna }} do pobrania',
+  'Malowanka {{ zmienna }} do druku A4',
+  'kolorowanka do druku {{ zmienna }} PDF',
+  'Łatwa kolorowanka {{ zmienna }} dla przedszkolaka',
+  'Edukacyjna kolorowanka {{ zmienna }} do wydruku',
+  'Kogut kolorowanka dla dzieci',
+  'Kolorowanka {{ zmienna }} – format A4 PDF',
+  'Prosta kolorowanka {{ zmienna }} do kolorowania',
+  'Jednorożec kolorowanka',
+  'Pokoloruj {{ zmienna }} – darmowy szablon PDF'
+];
+
+// Pobierz nazwę kategorii z argumentów
+const [, , category] = process.argv;
+if (!category) {
+  console.error("❌ Podaj nazwę kategorii jako argument, np. node update-alt.js koniki");
+  process.exit(1);
+}
+
+const folderPath = path.join('content', 'zwierzeta', category);
+
+fs.readdir(folderPath, (err, subdirs) => {
+  if (err) {
+    console.error(`\u274c Błąd przy odczycie folderu ${folderPath}`, err);
+    return;
+  }
+
+  subdirs.forEach((subdir, index) => {
+    const mdPath = path.join(folderPath, subdir, 'index.md');
+    if (!fs.existsSync(mdPath)) return;
+
+    const template = altTemplates[index % altTemplates.length];
+    const altText = template.replace('{{ zmienna }}', category);
+
+    const originalContent = fs.readFileSync(mdPath, 'utf8');
+    const parts = originalContent.split('---');
+
+    if (parts.length < 3) {
+      console.warn(`\u26a0\ufe0f Pominięto ${mdPath} – brak poprawnego frontmattera.`);
+      return;
+    }
+
+    let frontmatter = parts[1].trim();
+    const body = parts.slice(2).join('---');
+
+    // Usuń istniejący alt (jeśli jest), a potem dodaj nowy
+    frontmatter = frontmatter.replace(/^alt\s*:\s*.*$/m, '').trim();
+    frontmatter += `\nalt: "${altText}"`;
+
+    const updatedContent = `---\n${frontmatter}\n---${body}`;
+    fs.writeFileSync(mdPath, updatedContent, 'utf8');
+    console.log(`\u2705 Zaktualizowano alt w: ${mdPath}`);
+  });
+});


### PR DESCRIPTION
## Summary
- build ALT text templates into `svg-to-pdf.js`
- insert `alt` line when generating Markdown
- update README to show ALT in examples and mention optional `update-alt.js`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686919fcdd60832c834c1b33d6b90880